### PR TITLE
Separate PyPI publication to release-triggered workflow

### DIFF
--- a/.airflowignore
+++ b/.airflowignore
@@ -1,0 +1,17 @@
+# Ignore non-DAG directories to speed up parsing and avoid errors
+backups/.*
+cache/.*
+config/.*
+deploys/.*
+docs/.*
+extract/.*
+impactu/.*
+load/.*
+logs/.*
+plugins/.*
+tests/.*
+transform/.*
+\.git/.*
+\.github/.*
+\.venv/.*
+__pycache__/.*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,34 @@ jobs:
           export PYTHONPATH=$PYTHONPATH:.
           pytest tests/etl/test_scimagojr.py
 
+  publish-to-pypi:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies
+        run: |
+          pip install build twine
+
+      - name: Build package
+        run: |
+          python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python -m twine upload dist/*
+
   validate-on-dev:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,32 +83,6 @@ jobs:
           export PYTHONPATH=$PYTHONPATH:.
           pytest tests/etl/test_scimagojr.py
 
-  build-push:
-    needs: test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: colav/impactu_airflow:dags-prod
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   validate-on-dev:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,32 @@ jobs:
           export PYTHONPATH=$PYTHONPATH:.
           pytest tests/etl/test_scimagojr.py
 
+  build-push:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: colav/impactu_airflow:dags-prod
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   validate-on-dev:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ on:
     branches: [ "main" ]
   pull_request_target:
     branches: [ "main" ]
-    types: [labeled]
+    types: [labeled, synchronize]
   workflow_dispatch:
 
 jobs:
@@ -93,13 +93,6 @@ jobs:
       github.event_name == 'pull_request_target' &&
       contains(github.event.pull_request.labels.*.name, 'validate-on-dev')
     steps:
-      - name: Checkout PR code
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
       - name: Trigger PR Validation on Dev Airflow
         id: trigger_dag
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,12 +15,13 @@ on:
     branches: [ "main" ]
   pull_request_target:
     branches: [ "main" ]
-    types: [labeled, synchronize, opened, reopened]
+    types: [labeled]
   workflow_dispatch:
 
 jobs:
   code-quality:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request_target'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -46,6 +47,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request_target'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -92,6 +94,12 @@ jobs:
       github.event_name == 'pull_request_target' &&
       contains(github.event.pull_request.labels.*.name, 'validate-on-dev')
     steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Trigger PR Validation on Dev Airflow
         id: trigger_dag
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,6 @@ jobs:
           pytest tests/etl/test_scimagojr.py
 
   validate-on-dev:
-    needs: test
     runs-on: ubuntu-latest
     # Use pull_request_target to access secrets from forks
     # Only runs when a maintainer adds the "validate-on-dev" label
@@ -99,6 +98,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Trigger PR Validation on Dev Airflow
         id: trigger_dag

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,34 +83,6 @@ jobs:
           export PYTHONPATH=$PYTHONPATH:.
           pytest tests/etl/test_scimagojr.py
 
-  publish-to-pypi:
-    needs: test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install build dependencies
-        run: |
-          pip install build twine
-
-      - name: Build package
-        run: |
-          python -m build
-
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python -m twine upload dist/*
-
   validate-on-dev:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,15 +13,11 @@ on:
       - 'pyproject.toml'
   pull_request:
     branches: [ "main" ]
-  pull_request_target:
-    branches: [ "main" ]
-    types: [labeled, synchronize]
   workflow_dispatch:
 
 jobs:
   code-quality:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request_target'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,7 +43,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request_target'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -84,89 +79,3 @@ jobs:
         run: |
           export PYTHONPATH=$PYTHONPATH:.
           pytest tests/etl/test_scimagojr.py
-
-  validate-on-dev:
-    runs-on: ubuntu-latest
-    # Use pull_request_target to access secrets from forks
-    # Only runs when a maintainer adds the "validate-on-dev" label
-    if: |
-      github.event_name == 'pull_request_target' &&
-      contains(github.event.pull_request.labels.*.name, 'validate-on-dev')
-    steps:
-      - name: Trigger PR Validation on Dev Airflow
-        id: trigger_dag
-        run: |
-          echo "🚀 Triggering validation for PR #${{ github.event.pull_request.number }}..."
-          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "https://dev.airflow.colav.co/api/v2/dags/pr_validator/dagRuns" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${{ secrets.AIRFLOW_API_TOKEN }}" \
-            -d '{
-              "dag_run_id": "pr_${{ github.event.pull_request.number }}_${{ github.run_number }}",
-              "logical_date": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'",
-              "conf": {
-                "pr_number": ${{ github.event.pull_request.number }},
-                "repository": "${{ github.repository }}"
-              }
-            }')
-
-          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-          BODY=$(echo "$RESPONSE" | head -n-1)
-
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "❌ Failed to trigger DAG (HTTP $HTTP_CODE): $BODY"
-            exit 1
-          fi
-
-          DAG_RUN_ID=$(echo "$BODY" | jq -r '.dag_run_id')
-          echo "dag_run_id=$DAG_RUN_ID" >> $GITHUB_OUTPUT
-          echo "✅ Triggered: $DAG_RUN_ID"
-
-      - name: Wait for Validation Results
-        run: |
-          DAG_RUN_ID="${{ steps.trigger_dag.outputs.dag_run_id }}"
-          echo "⏱️ Polling validation status for $DAG_RUN_ID..."
-
-          MAX_ATTEMPTS=60  # 10 minutes max
-          ATTEMPT=0
-
-          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-            RESPONSE=$(curl -s "https://dev.airflow.colav.co/api/v2/dags/pr_validator/dagRuns/$DAG_RUN_ID" \
-              -H "Authorization: Bearer ${{ secrets.AIRFLOW_API_TOKEN }}")
-
-            STATE=$(echo "$RESPONSE" | jq -r '.state')
-            DURATION=$(echo "$RESPONSE" | jq -r '.duration // "running"')
-
-            echo "  Status: $STATE | Duration: ${DURATION}s"
-
-            if [ "$STATE" == "success" ]; then
-              echo "✅ Validation Passed!"
-              break
-            elif [ "$STATE" == "failed" ]; then
-              echo "❌ Validation Failed!"
-              echo ""
-              echo "📋 Fetching validation logs..."
-              curl -s "https://dev.airflow.colav.co/api/v2/dags/pr_validator/dagRuns/$DAG_RUN_ID/taskInstances/validate_pr/logs/1" \
-                -H "Authorization: Bearer ${{ secrets.AIRFLOW_API_TOKEN }}" \
-                | jq -r '.content[] | select(.event) | .event' \
-                | grep -E "ERROR|FAILED|✗|❌" || echo "$LOGS"
-              exit 1
-            elif [ "$STATE" == "null" ] || [ "$STATE" == "" ]; then
-              echo "⚠️ Error fetching status"
-              exit 1
-            fi
-
-            ATTEMPT=$((ATTEMPT + 1))
-            sleep 10
-          done
-
-          if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
-            echo "⏱️ Timeout waiting for validation"
-            exit 1
-          fi
-
-      - name: Post Validation Summary
-        if: always()
-        run: |
-          DAG_RUN_ID="${{ steps.trigger_dag.outputs.dag_run_id }}"
-          echo "📊 Full validation logs available at:"
-          echo "https://dev.airflow.colav.co/dags/pr_validator/grid?dag_run_id=$DAG_RUN_ID"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,4 +39,4 @@ jobs:
           sleep 10
           PACKAGE_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "Published version: $PACKAGE_VERSION"
-          echo "Check at: https://pypi.org/project/impactu-airflow/$PACKAGE_VERSION/"
+          echo "Check at: https://pypi.org/project/impactu_airflow/$PACKAGE_VERSION/"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies
+        run: |
+          pip install build twine
+
+      - name: Build package
+        run: |
+          python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python -m twine upload dist/*
+
+      - name: Verify publication
+        run: |
+          sleep 10
+          PACKAGE_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "Published version: $PACKAGE_VERSION"
+          echo "Check at: https://pypi.org/project/impactu-airflow/$PACKAGE_VERSION/"

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,90 @@
+name: Validate PR on Dev
+
+on:
+  pull_request_target:
+    branches: [ "main" ]
+    types: [labeled]
+
+jobs:
+  validate-on-dev:
+    runs-on: ubuntu-latest
+    # Only runs when a maintainer adds the "validate-on-dev" label
+    if: contains(github.event.pull_request.labels.*.name, 'validate-on-dev')
+    steps:
+      - name: Trigger PR Validation on Dev Airflow
+        id: trigger_dag
+        run: |
+          echo "🚀 Triggering validation for PR #${{ github.event.pull_request.number }}..."
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "https://dev.airflow.colav.co/api/v2/dags/pr_validator/dagRuns" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.AIRFLOW_API_TOKEN }}" \
+            -d '{
+              "dag_run_id": "pr_${{ github.event.pull_request.number }}_${{ github.run_number }}",
+              "logical_date": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'",
+              "conf": {
+                "pr_number": ${{ github.event.pull_request.number }},
+                "repository": "${{ github.repository }}"
+              }
+            }')
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+          BODY=$(echo "$RESPONSE" | head -n-1)
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "❌ Failed to trigger DAG (HTTP $HTTP_CODE): $BODY"
+            exit 1
+          fi
+
+          DAG_RUN_ID=$(echo "$BODY" | jq -r '.dag_run_id')
+          echo "dag_run_id=$DAG_RUN_ID" >> $GITHUB_OUTPUT
+          echo "✅ Triggered: $DAG_RUN_ID"
+
+      - name: Wait for Validation Results
+        run: |
+          DAG_RUN_ID="${{ steps.trigger_dag.outputs.dag_run_id }}"
+          echo "⏱️ Polling validation status for $DAG_RUN_ID..."
+
+          MAX_ATTEMPTS=60  # 10 minutes max
+          ATTEMPT=0
+
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            RESPONSE=$(curl -s "https://dev.airflow.colav.co/api/v2/dags/pr_validator/dagRuns/$DAG_RUN_ID" \
+              -H "Authorization: Bearer ${{ secrets.AIRFLOW_API_TOKEN }}")
+
+            STATE=$(echo "$RESPONSE" | jq -r '.state')
+            DURATION=$(echo "$RESPONSE" | jq -r '.duration // "running"')
+
+            echo "  Status: $STATE | Duration: ${DURATION}s"
+
+            if [ "$STATE" == "success" ]; then
+              echo "✅ Validation Passed!"
+              break
+            elif [ "$STATE" == "failed" ]; then
+              echo "❌ Validation Failed!"
+              echo ""
+              echo "📋 Fetching validation logs..."
+              curl -s "https://dev.airflow.colav.co/api/v2/dags/pr_validator/dagRuns/$DAG_RUN_ID/taskInstances/validate_pr/logs/1" \
+                -H "Authorization: Bearer ${{ secrets.AIRFLOW_API_TOKEN }}" \
+                | jq -r '.content[] | select(.event) | .event' \
+                | grep -E "ERROR|FAILED|✗|❌" || echo "$LOGS"
+              exit 1
+            elif [ "$STATE" == "null" ] || [ "$STATE" == "" ]; then
+              echo "⚠️ Error fetching status"
+              exit 1
+            fi
+
+            ATTEMPT=$((ATTEMPT + 1))
+            sleep 10
+          done
+
+          if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+            echo "⏱️ Timeout waiting for validation"
+            exit 1
+          fi
+
+      - name: Post Validation Summary
+        if: always()
+        run: |
+          DAG_RUN_ID="${{ steps.trigger_dag.outputs.dag_run_id }}"
+          echo "📊 Full validation logs available at:"
+          echo "https://dev.airflow.colav.co/dags/pr_validator/grid?dag_run_id=$DAG_RUN_ID"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Use the base image provided by the infrastructure
+FROM colav/impactu_airflow:base-latest
+
+# Install system dependencies
+USER root
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to airflow user
+USER airflow
+
+# Install Python dependencies
+COPY --chown=airflow:root requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the project structure
+COPY --chown=airflow:root . /opt/airflow/
+
+# Install the project in the image to make all modules (extract, transform, etc.)
+# available globally in the Python environment.
+RUN pip install --no-cache-dir .
+
+# Set the working directory
+WORKDIR /opt/airflow

--- a/README.md
+++ b/README.md
@@ -5,20 +5,37 @@
 [![Validate and Test DAGs](https://github.com/omazapa/impactu_airflow/actions/workflows/deploy.yml/badge.svg)](https://github.com/omazapa/impactu_airflow/actions/workflows/deploy.yml)
 # ImpactU Airflow ETL
 
-Central repository for Apache Airflow DAGs for the Extraction, Transformation, and Loading (ETL) processes of the ImpactU project.
+Central repository for Apache Airflow DAGs and ETL (Extraction, Transformation, and Loading) processes for the ImpactU project. This package includes the full logic for data orchestration, source extraction, and data processing.
 
 ## 🚀 Description
 This project orchestrates data collection from various scientific and academic sources, its processing using the [Kahi](https://github.com/colav/Kahi) tool, and its subsequent loading into query systems such as MongoDB and Elasticsearch.
 
-## 📂 Project Structure
-The repository is organized by data lifecycle stages:
+## � Installation
+You can install the package directly from PyPI:
 
+```bash
+pip install impactu_airflow
+```
+
+Or for development:
+
+```bash
+git clone https://github.com/colav/impactu_airflow.git
+cd impactu_airflow
+pip install -e .
+```
+
+## �📂 Project Structure
+The repository is organized by data lifecycle stages and Airflow components:
+
+*   `dags/`: Apache Airflow DAG definitions.
 *   `extract/`: Extraction logic for sources like OpenAlex, ORCID, ROR, etc.
 *   `transform/`: Transformation and normalization processes (Kahi).
-*   `load/`: Loading scripts to final destinations.
+*   `load/`: Loading scripts to final destinations (MongoDB, Elasticsearch).
+*   `impactu/`: Core utilities and shared logic for the project.
 *   `deploys/`: Deployment logic for external services (APIs, databases) via DAGs.
 *   `backups/`: Database backup automation via DAGs.
-*   `tests/`: Integration and data quality tests.
+*   `tests/`: Integration, unit, and data quality tests.
 
 ## 📋 Requirements and Architecture
 For details on design principles (Checkpoints, Idempotency, Parallelism), see the [System Requirements](REQUIREMENTS.md) document.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The repository is organized by data lifecycle stages:
 *   `extract/`: Extraction logic for sources like OpenAlex, ORCID, ROR, etc.
 *   `transform/`: Transformation and normalization processes (Kahi).
 *   `load/`: Loading scripts to final destinations.
-*   `deploys/`: Lógica de despliegue de servicios externos (APIs, bases de datos) mediante DAGs.
-*   `backups/`: Automatización de respaldos de bases de datos mediante DAGs.
+*   `deploys/`: Deployment logic for external services (APIs, databases) via DAGs.
+*   `backups/`: Database backup automation via DAGs.
 *   `tests/`: Integration and data quality tests.
 
 ## 📋 Requirements and Architecture
@@ -35,18 +35,18 @@ To maintain consistency in the Airflow interface, we follow this convention:
 | **Backup** | `backup_{db}_{name}` | `backup_mongodb_kahi` |
 | **Tests** | `tests_{service}` | `tests_kahi` |
 
-## ⚙️ Desarrollo y Despliegue
+## ⚙️ Development and Deployment
 
-Este repositorio se enfoca exclusivamente en la lógica de los DAGs y procesos ETL. La infraestructura base es provista por el repositorio **Chia**.
+This repository focuses exclusively on DAG logic and ETL processes. The base infrastructure is provided by the **Chia** repository.
 
-Para detalles sobre la estrategia de CI/CD, construcción de imágenes y gestión de entornos, consulta el documento:
+For details on the CI/CD strategy, image building, and environment management, see the document:
 👉 **[README_DEVOPS.md](README_DEVOPS.md)**
 
-### Flujo de Trabajo Local
-1. Clonar el repositorio.
-2. Instalar dependencias: `pip install -r requirements.txt`.
-3. Desarrollar DAGs en la carpeta `dags/`.
-4. Validar integridad: `pytest tests/etl/test_dag_integrity.py`.
+### Local Workflow
+1. Clone the repository.
+2. Install dependencies: `pip install -r requirements.txt`.
+3. Develop DAGs in the `dags/` folder.
+4. Validate integrity: `pytest tests/etl/test_dag_integrity.py`.
 
 ---
 **Colav - ImpactU**

--- a/README_DEVOPS.md
+++ b/README_DEVOPS.md
@@ -59,11 +59,13 @@ The `.github/workflows/deploy.yml` file manages the lifecycle:
 - **Remote Validation (PRs)**: When a PR is opened, CI notifies the Development Airflow API to run the `pr_validator` DAG. This DAG downloads the PR changes and validates them in the real Dev environment without needing to deploy the full image.
 
 ### Deployment Phase
-- **Production Sync**: Upon merging into `main`, the production server automatically synchronizes the DAG code via the `impactu_prod` bundle.
+- **PyPI Publication**: Upon merging into `main`, a GitHub Action builds and publishes the package to PyPI.
+- **Production Sync**: The production server automatically synchronizes the DAG code via the `impactu_prod` bundle.
 
 ## 5. Secrets and Configuration Management
 
 ### GitHub Secrets
+- `PYPI_PASSWORD`: PyPI API token for publishing the package.
 - `AIRFLOW_API_TOKEN`: Bearer token for CI to trigger validations on the Development server.
 - `GH_TOKEN_PR_VALIDATOR`: GitHub Token (Personal Access Token) with read permissions for the validator DAG to download PR files.
 

--- a/README_DEVOPS.md
+++ b/README_DEVOPS.md
@@ -2,14 +2,12 @@
 
 This document details the professional CI/CD strategy, environment management, and deployment for the `impactu_airflow` monorepo.
 
-## 1. Hybrid Architecture: Docker + DAG Bundles (Airflow 3.x)
+## 1. DAG Bundles Architecture (Airflow 3.x)
 
-For the production environment, we use a hybrid approach:
-- **Docker Image**: We build a custom image `colav/impactu_airflow:dags-prod` that contains all the project dependencies and the core logic (`extract/`, `transform/`, etc.). This ensures that the environment is consistent and all modules are available in the `PYTHONPATH`.
-- **DAG Bundles**: This native Airflow 3 feature allows the Scheduler and Webserver to consume DAGs directly from Git. This allows updating DAG logic without restarting containers, while the base image provides the heavy dependencies.
-
-- **Infrastructure**: The production environment pulls the `colav/impactu_airflow:dags-prod` image.
-- **Logic**: Changes in the `main` branch are automatically reflected via DAG Bundles and a new image is built and pushed to Docker Hub.
+For the production environment, we use DAG Bundles:
+- **DAG Bundles**: This native Airflow 3 feature allows the Scheduler and Webserver to consume DAGs directly from Git. This allows updating DAG logic automatically without restarting services.
+- **Dependencies**: All project dependencies are installed directly in the Airflow environment.
+- **Logic**: Changes in the `main` branch are automatically reflected via DAG Bundles, and the DAG Processor synchronizes files in real-time.
 
 ## 2. Production Strategy
 
@@ -22,7 +20,7 @@ For the production environment, we use a hybrid approach:
 2. Changes are developed in fork branches and validated locally.
 3. A **Pull Request (PR)** is opened from the fork to the `main` branch of the official repository.
 4. CI runs automatic tests and, if necessary, a remote validation in the development environment.
-5. Once approved and merged into `main`, the Airflow **DAG Processor** in production detects the update and synchronizes files in real-time.
+5. Once approved and merged into `main`, the Airflow DAG Processor in production detects the update and synchronizes files in real-time.
 
 ## 3. Production Server Configuration
 
@@ -61,14 +59,12 @@ The `.github/workflows/deploy.yml` file manages the lifecycle:
 - **Remote Validation (PRs)**: When a PR is opened, CI notifies the Development Airflow API to run the `pr_validator` DAG. This DAG downloads the PR changes and validates them in the real Dev environment without needing to deploy the full image.
 
 ### Deployment Phase
-- **Docker Build**: Upon merging into `main`, a GitHub Action builds the `colav/impactu_airflow:dags-prod` image and pushes it to Docker Hub.
-- **Production Sync**: The production server automatically synchronizes the DAG code via the `impactu_prod` bundle.
+- **Production Sync**: Upon merging into `main`, the production server automatically synchronizes the DAG code via the `impactu_prod` bundle.
 
 ## 5. Secrets and Configuration Management
 
 ### GitHub Secrets
-- `DOCKER_USERNAME` / `DOCKER_PASSWORD`: Credentials to push the image to Docker Hub.
-- `AIRFLOW_API_USER` / `AIRFLOW_API_PASSWORD`: Credentials for CI to trigger validations on the Development server.
+- `AIRFLOW_API_TOKEN`: Bearer token for CI to trigger validations on the Development server.
 - `GH_TOKEN_PR_VALIDATOR`: GitHub Token (Personal Access Token) with read permissions for the validator DAG to download PR files.
 
 ### Airflow (Runtime)

--- a/README_DEVOPS.md
+++ b/README_DEVOPS.md
@@ -59,7 +59,7 @@ The `.github/workflows/deploy.yml` file manages the lifecycle:
 - **Remote Validation (PRs)**: When a PR is opened, CI notifies the Development Airflow API to run the `pr_validator` DAG. This DAG downloads the PR changes and validates them in the real Dev environment without needing to deploy the full image.
 
 ### Deployment Phase
-- **PyPI Publication**: Upon merging into `main`, a GitHub Action builds and publishes the package to PyPI.
+- **PyPI Publication**: When a new release is published on GitHub, a workflow automatically builds and publishes the package to PyPI.
 - **Production Sync**: The production server automatically synchronizes the DAG code via the `impactu_prod` bundle.
 
 ## 5. Secrets and Configuration Management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,33 @@
 [project]
 name = "impactu_airflow"
 version = "0.1.0"
-description = "Apache Airflow DAGs for ImpactU ETL processes"
+description = "Apache Airflow DAGs and ETL processes for ImpactU"
+readme = "README.md"
 requires-python = ">=3.12"
+license = {text = "BSD-2-Clause"}
+authors = [
+    {name = "Colav", email = "grupocolav@udea.edu.co"}
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Framework :: Apache Airflow",
+]
+dependencies = [
+    "apache-airflow-providers-mongo>=5.3.0",
+    "pymongo>=4.15.5",
+    "pandas>=2.1.4",
+    "requests>=2.32.5",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["*"]
+exclude = ["tests*", "docs*", "logs*", "cache*"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## 🔧 CI/CD Improvements and Workflow Refactoring

### Overview
This PR refactors the CI/CD pipeline to improve clarity, remove Docker dependencies, and add PyPI publication support.

### Changes

#### 🐳 Docker Removal
- Removed Docker build and push workflow from CI/CD
- Updated documentation to reflect DAG Bundles-only deployment strategy
- Removed Docker-related secrets from documentation

#### 📦 PyPI Publication
- Created dedicated `publish.yml` workflow for package publication
- Triggers automatically on GitHub releases
- Uses `PYPI_PASSWORD` secret for authentication
- Includes post-publication verification step

#### 🔄 Workflow Separation
- Split `deploy.yml` into two focused workflows:
  - **`deploy.yml`**: Standard PR validation and testing (code-quality, tests)
  - **`validate-pr.yml`**: Remote validation on dev environment (manual trigger via label)
- Eliminated duplicate workflow runs and `pull_request_target` conflicts
- Fixed "Similar commit hashes" error by removing unnecessary checkout steps

#### 📝 Documentation Updates
- Updated `README_DEVOPS.md` with new deployment strategy
- Clarified GitHub Secrets requirements
- Removed references to Docker Hub credentials

#### 🛠️ Bug Fixes
- Resolved workflow execution issues with `pull_request_target` event

### Testing
- ✅ All existing tests pass
- ✅ Workflows validated on test PR
- ✅ No breaking changes to existing DAGs

### Deployment Notes
- After merge, update `PYPI_PASSWORD` secret in repository settings
- Ensure `AIRFLOW_API_TOKEN` is configured for PR validation workflow
- Create GitHub release to trigger PyPI publication